### PR TITLE
fix: add missing kudu private dns record

### DIFF
--- a/private_dns.tf
+++ b/private_dns.tf
@@ -89,3 +89,11 @@ resource "azurerm_private_dns_a_record" "function_app" {
   ttl                 = 300
   records             = [azurerm_private_endpoint.function_app.private_service_connection[0].private_ip_address]
 }
+
+resource "azurerm_private_dns_a_record" "function_app_kudu" {
+  name                = "${azurerm_function_app_flex_consumption.cost_export.name}.scm"
+  zone_name           = azurerm_private_dns_zone.sites.name
+  resource_group_name = azurerm_resource_group.cost_export.name
+  ttl                 = 300
+  records             = [azurerm_private_endpoint.function_app.private_service_connection[0].private_ip_address]
+}


### PR DESCRIPTION
## what

Adding missing DNS record for the function app source control host name (scm).

## why

Function app deployment fails using private GitHub runners with this record missing.

## references

closes #24
