### PR TITLE
test: add billing account contributor role to function app managed id…

### DIFF
--- a/rbac.tf
+++ b/rbac.tf
@@ -73,3 +73,29 @@ resource "azurerm_role_assignment" "advisor_reader" {
   principal_id         = azurerm_function_app_flex_consumption.cost_export.identity[0].principal_id
   principal_type       = "ServicePrincipal"
 }
+
+resource "azapi_resource_action" "add_role_assignment" {
+  for_each = toset(var.billing_account_ids)
+
+  type                   = "Microsoft.Billing/billingAccounts@2019-10-01-preview"
+  resource_id            = "/providers/Microsoft.Billing/billingAccounts/${each.value}"
+  action                 = "createBillingRoleAssignment"
+  method                 = "POST"
+  when                   = "apply"
+  response_export_values = ["*"]
+  body = jsonencode({
+    properties = {
+      principalId = azurerm_function_app_flex_consumption.cost_export.identity[0].principal_id
+      # TODO: Look this up dynamically https://learn.microsoft.com/en-us/rest/api/billing/billing-role-definition/list-by-billing-account?view=rest-billing-2024-04-01&tabs=HTTP
+      roleDefinitionId = "/providers/Microsoft.Billing/billingAccounts/${each.value}/billingRoleDefinitions/50000000-aaaa-bbbb-cccc-100000000001"
+    }
+  })
+}
+
+resource "azapi_resource_action" "remove_role_assignment" {
+  for_each    = toset(var.billing_account_ids)
+  type        = "Microsoft.Billing/billingAccounts/billingRoleAssignments@2019-10-01-preview"
+  resource_id = jsondecode(azapi_resource_action.add_role_assignment[each.key].output).id
+  method      = "DELETE"
+  when        = "destroy"
+}


### PR DESCRIPTION
## what

- Adds the function app managed identity as a billing account contributor (hopefully)

## why

The function app needs permission to create focus cost exports in Cost Management.