### PR TITLE
feat: add tags support to multiple resources

### DIFF
--- a/event_grid.tf
+++ b/event_grid.tf
@@ -8,6 +8,8 @@ resource "azurerm_eventgrid_system_topic" "storage_events" {
   identity {
     type = "SystemAssigned"
   }
+
+  tags = var.tags
 }
 
 resource "azurerm_eventgrid_event_subscription" "focus_blob_created" {

--- a/function_app.tf
+++ b/function_app.tf
@@ -4,12 +4,14 @@ resource "azurerm_service_plan" "cost_export" {
   location            = azurerm_resource_group.cost_export.location
   os_type             = "Linux"
   sku_name            = "FC1"
+  tags                = var.tags
 }
 
 resource "azurerm_function_app_flex_consumption" "cost_export" {
   name                = "func-cost-export-${random_string.unique.result}"
   resource_group_name = azurerm_resource_group.cost_export.name
   location            = azurerm_resource_group.cost_export.location
+  tags                = var.tags
 
   storage_container_type = "blobContainer"
   # TODO: Switch to managed identity once this is fixed:
@@ -105,7 +107,7 @@ resource "azurerm_application_insights" "this" {
   local_authentication_disabled         = false
   retention_in_days                     = 90
   sampling_percentage                   = 100
-  tags                                  = {}
+  tags                                  = var.tags
 }
 
 resource "null_resource" "publish_function_code" {

--- a/private_dns.tf
+++ b/private_dns.tf
@@ -1,26 +1,31 @@
 resource "azurerm_private_dns_zone" "blob" {
   name                = "privatelink.blob.core.windows.net"
   resource_group_name = azurerm_resource_group.cost_export.name
+  tags                = var.tags
 }
 
 resource "azurerm_private_dns_zone" "file" {
   name                = "privatelink.file.core.windows.net"
   resource_group_name = azurerm_resource_group.cost_export.name
+  tags                = var.tags
 }
 
 resource "azurerm_private_dns_zone" "table" {
   name                = "privatelink.table.core.windows.net"
   resource_group_name = azurerm_resource_group.cost_export.name
+  tags                = var.tags
 }
 
 resource "azurerm_private_dns_zone" "queue" {
   name                = "privatelink.queue.core.windows.net"
   resource_group_name = azurerm_resource_group.cost_export.name
+  tags                = var.tags
 }
 
 resource "azurerm_private_dns_zone" "sites" {
   name                = "privatelink.azurewebsites.net"
   resource_group_name = azurerm_resource_group.cost_export.name
+  tags                = var.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "blob" {
@@ -28,6 +33,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "blob" {
   resource_group_name   = azurerm_resource_group.cost_export.name
   private_dns_zone_name = azurerm_private_dns_zone.blob.name
   virtual_network_id    = data.azurerm_virtual_network.existing.id
+  tags                  = var.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "file" {
@@ -35,6 +41,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "file" {
   resource_group_name   = azurerm_resource_group.cost_export.name
   private_dns_zone_name = azurerm_private_dns_zone.file.name
   virtual_network_id    = data.azurerm_virtual_network.existing.id
+  tags                  = var.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "table" {
@@ -42,6 +49,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "table" {
   resource_group_name   = azurerm_resource_group.cost_export.name
   private_dns_zone_name = azurerm_private_dns_zone.table.name
   virtual_network_id    = data.azurerm_virtual_network.existing.id
+  tags                  = var.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "queue" {
@@ -49,6 +57,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "queue" {
   resource_group_name   = azurerm_resource_group.cost_export.name
   private_dns_zone_name = azurerm_private_dns_zone.queue.name
   virtual_network_id    = data.azurerm_virtual_network.existing.id
+  tags                  = var.tags
 }
 
 resource "azurerm_private_dns_zone_virtual_network_link" "sites" {
@@ -56,6 +65,7 @@ resource "azurerm_private_dns_zone_virtual_network_link" "sites" {
   resource_group_name   = azurerm_resource_group.cost_export.name
   private_dns_zone_name = azurerm_private_dns_zone.sites.name
   virtual_network_id    = data.azurerm_virtual_network.existing.id
+  tags                  = var.tags
 }
 
 resource "azurerm_private_dns_a_record" "storage" {
@@ -64,6 +74,7 @@ resource "azurerm_private_dns_a_record" "storage" {
   resource_group_name = azurerm_resource_group.cost_export.name
   ttl                 = 300
   records             = [azurerm_private_endpoint.storage.private_service_connection[0].private_ip_address]
+  tags                = var.tags
 }
 
 resource "azurerm_private_dns_a_record" "storage_queue" {
@@ -72,6 +83,7 @@ resource "azurerm_private_dns_a_record" "storage_queue" {
   resource_group_name = azurerm_resource_group.cost_export.name
   ttl                 = 300
   records             = [azurerm_private_endpoint.storage_queue.private_service_connection[0].private_ip_address]
+  tags                = var.tags
 }
 
 resource "azurerm_private_dns_a_record" "deployment" {
@@ -80,6 +92,7 @@ resource "azurerm_private_dns_a_record" "deployment" {
   resource_group_name = azurerm_resource_group.cost_export.name
   ttl                 = 300
   records             = [azurerm_private_endpoint.deployment.private_service_connection[0].private_ip_address]
+  tags                = var.tags
 }
 
 resource "azurerm_private_dns_a_record" "function_app" {
@@ -88,6 +101,7 @@ resource "azurerm_private_dns_a_record" "function_app" {
   resource_group_name = azurerm_resource_group.cost_export.name
   ttl                 = 300
   records             = [azurerm_private_endpoint.function_app.private_service_connection[0].private_ip_address]
+  tags                = var.tags
 }
 
 resource "azurerm_private_dns_a_record" "function_app_kudu" {
@@ -96,4 +110,5 @@ resource "azurerm_private_dns_a_record" "function_app_kudu" {
   resource_group_name = azurerm_resource_group.cost_export.name
   ttl                 = 300
   records             = [azurerm_private_endpoint.function_app.private_service_connection[0].private_ip_address]
+  tags                = var.tags
 }

--- a/private_endpoints.tf
+++ b/private_endpoints.tf
@@ -3,6 +3,7 @@ resource "azurerm_private_endpoint" "storage" {
   location            = azurerm_resource_group.cost_export.location
   resource_group_name = azurerm_resource_group.cost_export.name
   subnet_id           = var.subnet_id
+  tags                = var.tags
 
   private_service_connection {
     name                           = "psc-storage-cost-export"
@@ -21,6 +22,7 @@ resource "azurerm_private_endpoint" "storage_queue" {
   location            = azurerm_resource_group.cost_export.location
   resource_group_name = azurerm_resource_group.cost_export.name
   subnet_id           = var.subnet_id
+  tags                = var.tags
 
   private_service_connection {
     name                           = "psc-storage-queue-cost-export"
@@ -57,6 +59,7 @@ resource "azurerm_private_endpoint" "function_app" {
   location            = azurerm_resource_group.cost_export.location
   resource_group_name = azurerm_resource_group.cost_export.name
   subnet_id           = var.subnet_id
+  tags                = var.tags
 
   private_service_connection {
     name                           = "psc-func-cost-export"

--- a/resource_group.tf
+++ b/resource_group.tf
@@ -1,6 +1,7 @@
 resource "azurerm_resource_group" "cost_export" {
   name     = var.resource_group_name
   location = var.location
+  tags     = var.tags
 }
 
 resource "random_string" "unique" {

--- a/storage.tf
+++ b/storage.tf
@@ -5,6 +5,7 @@ resource "azurerm_storage_account" "cost_export" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
   is_hns_enabled           = true
+  tags                     = var.tags
 
   public_network_access_enabled = false
 
@@ -39,6 +40,7 @@ resource "azurerm_storage_account" "deployment" {
   account_tier             = "Standard"
   account_replication_type = "LRS"
   is_hns_enabled           = true
+  tags                     = var.tags
 
   public_network_access_enabled = false
 

--- a/variables.tf
+++ b/variables.tf
@@ -110,3 +110,9 @@ variable "is_enterprise_customer" {
   type        = bool
   default     = false
 }
+
+variable "tags" {
+  description = "Tags to apply to all resources"
+  type        = map(string)
+  default     = {}
+}


### PR DESCRIPTION
what
- Introduce a new variable `tags` in variables.tf
- Applies `var.tags` to all supported Azure resources within the solution including: resource group, storage accounts, Event Grid topic, private DNS zones, DNS virtual network links, DNS A records, private endpoints, service plan, function app, and Application Insights

why
- I was tasked in assisting implementing this for a customer today, however specific tags are required and enforced by Azure Policy in their Environment. Policy prevented the deployment due to the required tags not being present on the resource group (_inherits down in this customers scenario_), `azurerm_resource_group.cost_export` and not being able to pass them in natively. I appreciate not all consumers who enforce tags through Policy may have such inheritance behaviour configured, so have applied the variable to all supported resources. 
- Consistent tagging across all resources enables accurate cost allocation, resource organisation, facilitates automation and ensures compliance with policy.