### PR TITLE
fix: update PowerShell interpreter to avoid profile loading

### DIFF
--- a/function_app.tf
+++ b/function_app.tf
@@ -110,7 +110,7 @@ resource "azurerm_application_insights" "this" {
 
 resource "null_resource" "publish_function_code" {
   provisioner "local-exec" {
-    interpreter = ["pwsh", "-Command"]
+    interpreter = ["pwsh", "-NoProfile", "-Command"]
     command     = local.publish_code_command
   }
 


### PR DESCRIPTION
## what

Prevent deployment script from loading PowerShell profile.

## why

To ensure a clean terminal environment and avoid errors.
