### PR TITLE
feat: update README to include tags input for resource management

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@
 #
 .PHONY: all security lint format documentation documentation-examples validate-all validate validate-examples init examples tests tests-python python-setup python-lint python-format
 
+TERRAFORM_DOCS_DOCKER=docker run --rm --volume "$$(pwd):/workspace" --workdir /workspace -u $$(id -u) quay.io/terraform-docs/terraform-docs:0.20.0
+
 default: all
 
 all: 
@@ -37,7 +39,7 @@ examples:
 
 documentation: 
 	@echo "--> Generating documentation"
-	@terraform-docs .
+	@$(TERRAFORM_DOCS_DOCKER) markdown .
 	$(MAKE) documentation-modules
 	$(MAKE) documentation-examples
 
@@ -45,14 +47,14 @@ documentation-modules:
 	@echo "--> Generating documentation for modules"
 	@find . -type d -regex '.*/modules/[a-za-z\-_$$]*' -not -path '*.terraform*' 2>/dev/null | while read -r dir; do \
 		echo "--> Generating documentation for module: $$dir"; \
-		terraform-docs $$dir; \
+		$(TERRAFORM_DOCS_DOCKER) markdown $$dir; \
 	done;
 
 documentation-examples:
 	@echo "--> Generating documentation for examples"
 	@find . -type d -path '*/examples/*' -not -path '*.terraform*' 2>/dev/null| while read -r dir; do \
 		echo "--> Generating documentation for example: $$dir"; \
-		terraform-docs $$dir; \
+		$(TERRAFORM_DOCS_DOCKER) markdown $$dir; \
 	done;
 
 upgrade-terraform-providers:

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.0 |
 | <a name="provider_azapi"></a> [azapi](#provider\_azapi) | >= 1.7.0 |
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | > 2.0 |
@@ -324,7 +324,7 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS account ID to use for the S3 bucket | `string` | n/a | yes |
 | <a name="input_billing_account_ids"></a> [billing\_account\_ids](#input\_billing\_account\_ids) | List of billing account IDs to create FOCUS cost exports for. Use the billing account ID format from Azure portal (e.g., 'bdfa614c-3bed-5e6d-313b-b4bfa3cefe1d:16e4ddda-0100-468b-a32c-abbfc29019d8\_2019-05-31') | `list(string)` | n/a | yes |
 | <a name="input_function_app_subnet_id"></a> [function\_app\_subnet\_id](#input\_function\_app\_subnet\_id) | ID of the subnet to connect the function app to. This subnet must have delegation configured for Microsoft.App/environments and must be in the same virtual network as the private endpoints | `string` | n/a | yes |
@@ -343,11 +343,12 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 | <a name="input_is_enterprise_customer"></a> [is\_enterprise\_customer](#input\_is\_enterprise\_customer) | Set to true if you are an Enterprise Agreement customer | `bool` | `false` | no |
 | <a name="input_location"></a> [location](#input\_location) | The Azure region where resources will be created | `string` | `"uksouth"` | no |
 | <a name="input_logging_level"></a> [logging\_level](#input\_logging\_level) | Logging level for the app; can be DEBUG or INFO (default) | `string` | `"INFO"` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to all resources | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_aws_app_client_id"></a> [aws\_app\_client\_id](#output\_aws\_app\_client\_id) | The aws app client id |
 | <a name="output_billing_account_ids"></a> [billing\_account\_ids](#output\_billing\_account\_ids) | Billing account IDs configured for cost reporting |
 | <a name="output_billing_accounts_map"></a> [billing\_accounts\_map](#output\_billing\_accounts\_map) | Map of billing account indices to IDs and scopes |

--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_archive"></a> [archive](#provider\_archive) | >= 2.0 |
 | <a name="provider_azapi"></a> [azapi](#provider\_azapi) | >= 1.7.0 |
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | > 2.0 |
@@ -324,7 +324,7 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
+|------|-------------|------|---------|:--------:|
 | <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | AWS account ID to use for the S3 bucket | `string` | n/a | yes |
 | <a name="input_billing_account_ids"></a> [billing\_account\_ids](#input\_billing\_account\_ids) | List of billing account IDs to create FOCUS cost exports for. Use the billing account ID format from Azure portal (e.g., 'bdfa614c-3bed-5e6d-313b-b4bfa3cefe1d:16e4ddda-0100-468b-a32c-abbfc29019d8\_2019-05-31') | `list(string)` | n/a | yes |
 | <a name="input_function_app_subnet_id"></a> [function\_app\_subnet\_id](#input\_function\_app\_subnet\_id) | ID of the subnet to connect the function app to. This subnet must have delegation configured for Microsoft.App/environments and must be in the same virtual network as the private endpoints | `string` | n/a | yes |
@@ -348,7 +348,7 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_aws_app_client_id"></a> [aws\_app\_client\_id](#output\_aws\_app\_client\_id) | The aws app client id |
 | <a name="output_billing_account_ids"></a> [billing\_account\_ids](#output\_billing\_account\_ids) | Billing account IDs configured for cost reporting |
 | <a name="output_billing_accounts_map"></a> [billing\_accounts\_map](#output\_billing\_accounts\_map) | Map of billing account indices to IDs and scopes |


### PR DESCRIPTION
## what

- Update README.md to include docs for tags variable
- Change terraform-docs in Makefile to use docker

## why

The recent change to add tags variable did not include docs update.
terraform-docs >= 0.22.0 formats slightly differently so causes failures in workflows. Using docker based version allows it to be pinned to 0.20.0 and avoid issues with local versions 

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow).
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
