### PR TITLE
feat: expand outputs in README and outputs.tf for cost export and deployment resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,11 +355,24 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 | <a name="output_carbon_container_name"></a> [carbon\_container\_name](#output\_carbon\_container\_name) | The storage container name for carbon data (not used - carbon data goes directly to S3) |
 | <a name="output_carbon_export_name"></a> [carbon\_export\_name](#output\_carbon\_export\_name) | The name of the carbon optimization export (timer-triggered function) |
 | <a name="output_cost_export_app_principal_id"></a> [cost\_export\_app\_principal\_id](#output\_cost\_export\_app\_principal\_id) | The principal id of the cost export app - use this to assign Enrollment Reader role |
+| <a name="output_cost_export_storage_account_id"></a> [cost\_export\_storage\_account\_id](#output\_cost\_export\_storage\_account\_id) | The resource id of the cost export storage account |
+| <a name="output_cost_export_storage_account_name"></a> [cost\_export\_storage\_account\_name](#output\_cost\_export\_storage\_account\_name) | The name of the cost export storage account |
 | <a name="output_current_principal_type"></a> [current\_principal\_type](#output\_current\_principal\_type) | Principal type of the current Azure client (ServicePrincipal or User) |
+| <a name="output_deployment_storage_account_id"></a> [deployment\_storage\_account\_id](#output\_deployment\_storage\_account\_id) | The resource id of the deployment storage account |
+| <a name="output_deployment_storage_account_name"></a> [deployment\_storage\_account\_name](#output\_deployment\_storage\_account\_name) | The name of the deployment storage account |
+| <a name="output_deployment_storage_private_endpoint_ip"></a> [deployment\_storage\_private\_endpoint\_ip](#output\_deployment\_storage\_private\_endpoint\_ip) | The private IP address of the deployment storage blob private endpoint |
 | <a name="output_ea_billing_role_definition_ids"></a> [ea\_billing\_role\_definition\_ids](#output\_ea\_billing\_role\_definition\_ids) | The set of roleDefinitionId - use each of these as input to the Enrollment Reader JSON body - must match the billing id in the URL |
+| <a name="output_event_grid_subscription_name"></a> [event\_grid\_subscription\_name](#output\_event\_grid\_subscription\_name) | The name of the Event Grid subscription for blob created events |
+| <a name="output_event_grid_system_topic_name"></a> [event\_grid\_system\_topic\_name](#output\_event\_grid\_system\_topic\_name) | The name of the Event Grid system topic for storage events |
 | <a name="output_focus_container_name"></a> [focus\_container\_name](#output\_focus\_container\_name) | The storage container name for FOCUS cost data |
+| <a name="output_function_app_id"></a> [function\_app\_id](#output\_function\_app\_id) | The resource id of the cost export function app |
+| <a name="output_function_app_name"></a> [function\_app\_name](#output\_function\_app\_name) | The name of the cost export function app |
+| <a name="output_function_app_private_endpoint_ip"></a> [function\_app\_private\_endpoint\_ip](#output\_function\_app\_private\_endpoint\_ip) | The private IP address of the function app private endpoint |
 | <a name="output_publish_code_command"></a> [publish\_code\_command](#output\_publish\_code\_command) | Publish code command for debugging |
+| <a name="output_random_string_suffix"></a> [random\_string\_suffix](#output\_random\_string\_suffix) | The random suffix appended to generated resource names |
 | <a name="output_recommendations_export_name"></a> [recommendations\_export\_name](#output\_recommendations\_export\_name) | The name of the Azure Advisor recommendations export (timer-triggered function) |
 | <a name="output_report_scopes"></a> [report\_scopes](#output\_report\_scopes) | Report scopes created for each billing account |
+| <a name="output_storage_private_endpoint_ip"></a> [storage\_private\_endpoint\_ip](#output\_storage\_private\_endpoint\_ip) | The private IP address of the cost export storage blob private endpoint |
+| <a name="output_storage_queue_private_endpoint_ip"></a> [storage\_queue\_private\_endpoint\_ip](#output\_storage\_queue\_private\_endpoint\_ip) | The private IP address of the cost export storage queue private endpoint |
 | <a name="output_tenant_id"></a> [tenant\_id](#output\_tenant\_id) | The tenant id - use this to assign the Enrollment Reader role |
 <!-- END_TF_DOCS -->

--- a/outputs.tf
+++ b/outputs.tf
@@ -62,3 +62,68 @@ output "ea_billing_role_definition_ids" {
   description = "The set of roleDefinitionId - use each of these as input to the Enrollment Reader JSON body - must match the billing id in the URL"
   value       = [for v in var.billing_account_ids : "/providers/Microsoft.Billing/billingAccounts/${v}/billingRoleDefinitions/24f8edb6-1668-4659-b5e2-40bb5f3a7d7e"]
 }
+
+output "random_string_suffix" {
+  description = "The random suffix appended to generated resource names"
+  value       = random_string.unique.result
+}
+
+output "cost_export_storage_account_name" {
+  description = "The name of the cost export storage account"
+  value       = azurerm_storage_account.cost_export.name
+}
+
+output "deployment_storage_account_name" {
+  description = "The name of the deployment storage account"
+  value       = azurerm_storage_account.deployment.name
+}
+
+output "function_app_name" {
+  description = "The name of the cost export function app"
+  value       = azurerm_function_app_flex_consumption.cost_export.name
+}
+
+output "event_grid_system_topic_name" {
+  description = "The name of the Event Grid system topic for storage events"
+  value       = azurerm_eventgrid_system_topic.storage_events.name
+}
+
+output "event_grid_subscription_name" {
+  description = "The name of the Event Grid subscription for blob created events"
+  value       = azurerm_eventgrid_event_subscription.focus_blob_created.name
+}
+
+output "cost_export_storage_account_id" {
+  description = "The resource id of the cost export storage account"
+  value       = azurerm_storage_account.cost_export.id
+}
+
+output "deployment_storage_account_id" {
+  description = "The resource id of the deployment storage account"
+  value       = azurerm_storage_account.deployment.id
+}
+
+output "function_app_id" {
+  description = "The resource id of the cost export function app"
+  value       = azurerm_function_app_flex_consumption.cost_export.id
+}
+
+output "storage_private_endpoint_ip" {
+  description = "The private IP address of the cost export storage blob private endpoint"
+  value       = azurerm_private_endpoint.storage.private_service_connection[0].private_ip_address
+}
+
+output "storage_queue_private_endpoint_ip" {
+  description = "The private IP address of the cost export storage queue private endpoint"
+  value       = azurerm_private_endpoint.storage_queue.private_service_connection[0].private_ip_address
+}
+
+output "deployment_storage_private_endpoint_ip" {
+  description = "The private IP address of the deployment storage blob private endpoint"
+  value       = azurerm_private_endpoint.deployment.private_service_connection[0].private_ip_address
+}
+
+output "function_app_private_endpoint_ip" {
+  description = "The private IP address of the function app private endpoint"
+  value       = azurerm_private_endpoint.function_app.private_service_connection[0].private_ip_address
+}


### PR DESCRIPTION
## what

Expand the outputs of the module to provide names of created resources

## why

Useful for users of the module to have information on resources that have been created.

## references

closes #54